### PR TITLE
secrets-manager-read-onlyのpolicy追加

### DIFF
--- a/cfn/eks-nodes-bottlerocket.yaml
+++ b/cfn/eks-nodes-bottlerocket.yaml
@@ -139,6 +139,16 @@ Resources:
                   - "ivs:*"
                 Resource: "*"
           PolicyName: "ivs-full-access"
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "secretsmanager:GetResourcePolicy"
+                  - "secretsmanager:GetSecretValue"
+                  - "secretsmanager:DescribeSecret"
+                  - "secretsmanager:ListSecretVersionIds"
+                Resource: "*"
+          PolicyName: "secrets-manager-read-only"
       Path: /
       Tags:
         - Key: Name


### PR DESCRIPTION
close #5 

secrets-manager-read-onlyのpolicyがcfnで管理されていなかったため追加