### PR TITLE
move VPC S3 Endpoint to vpc.yaml from s3.yaml

### DIFF
--- a/cfn/s3.yaml
+++ b/cfn/s3.yaml
@@ -33,4 +33,4 @@ Outputs:
   S3BucketName:
     Value: !Ref S3Bucket
     Export:
-      Name: !Sub "${PJPrefix}-bucket-id"
+      Name: !Sub "${PJPrefix}-${S3BucketName}-id"

--- a/cfn/s3.yaml
+++ b/cfn/s3.yaml
@@ -5,7 +5,6 @@ Parameters:
   PJPrefix:
     Type: String
     Default: "dreamkast-codt"
-#S3BucketName
   S3BucketName:
     Type: String
     Default: "bucket"
@@ -27,18 +26,6 @@ Resources:
         RestrictPublicBuckets: True
 
 # ------------------------------------------------------------#
-#  VPCS3Endpoint
-# ------------------------------------------------------------#
-  VPCS3Endpoint:
-    Type: "AWS::EC2::VPCEndpoint"
-    Properties:
-      RouteTableIds:
-        - { "Fn::ImportValue": !Sub "${PJPrefix}-private-route-a" }
-        - { "Fn::ImportValue": !Sub "${PJPrefix}-private-route-c" }
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
-      VpcId: { "Fn::ImportValue": !Sub "${PJPrefix}-vpc" }
-
-# ------------------------------------------------------------#
 # Output Parameters
 # ------------------------------------------------------------#
 Outputs:
@@ -47,9 +34,3 @@ Outputs:
     Value: !Ref S3Bucket
     Export:
       Name: !Sub "${PJPrefix}-bucket-id"
-
-#VPCS3Endpoint
-  VPCS3Endpoint:
-    Value: !Ref VPCS3Endpoint
-    Export:
-      Name: !Sub "${PJPrefix}-vpcs3endpoint-id"

--- a/cfn/vpc.yaml
+++ b/cfn/vpc.yaml
@@ -308,6 +308,18 @@ Resources:
       Domain: vpc
 
 # ------------------------------------------------------------#
+#  VPCS3Endpoint
+# ------------------------------------------------------------#
+  VPCS3Endpoint:
+    Type: "AWS::EC2::VPCEndpoint"
+    Properties:
+      RouteTableIds:
+        - { "Fn::ImportValue": !Sub "${PJPrefix}-private-route-a" }
+        - { "Fn::ImportValue": !Sub "${PJPrefix}-private-route-c" }
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
+      VpcId: { "Fn::ImportValue": !Sub "${PJPrefix}-vpc" }
+
+# ------------------------------------------------------------#
 # Output Parameters
 # ------------------------------------------------------------#
 Outputs:
@@ -383,3 +395,9 @@ Outputs:
     Value: !Ref PrivateRouteTableC
     Export:
       Name: !Sub "${PJPrefix}-private-route-c"
+
+#VPCS3Endpoint
+  VPCS3Endpoint:
+    Value: !Ref VPCS3Endpoint
+    Export:
+      Name: !Sub "${PJPrefix}-vpcs3endpoint-id"


### PR DESCRIPTION
S3用のStackを2つ作ろうとするとVPCS3Endpointがコンフリクトする問題を解決します。VPCS3Endpointはvpc.yamlに移動しました。また、s3.yamlのOutoutも同じ名前になってコンフリクトするので変数を使うように変更しています。